### PR TITLE
Add error handling to scanner.py

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,27 +1,65 @@
 import sys
 import os
+import re
+import shlex
+import ollama
 from scanner import find_relevant_file
+
+def generate_fix(target_file, title, body):
+    """Read the target file, ask Ollama for a fix, and write it back."""
+    with open(target_file, "r") as f:
+        original_code = f.read()
+
+    body = body or ""
+    prompt = (
+        f"You are a senior developer. A GitHub issue was filed:\n"
+        f"Title: {title}\n"
+        f"Description: {body}\n\n"
+        f"Here is the current content of `{target_file}`:\n"
+        f"```\n{original_code}\n```\n\n"
+        f"Return ONLY the complete updated file content that addresses the issue. "
+        f"No markdown fences, no explanation, no commentary — just the raw code."
+    )
+
+    print(f"🤖 Generating fix for {target_file}...")
+    response = ollama.chat(
+        model="llama3.1:8b-instruct-q8_0",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    fixed_code = response["message"]["content"].strip()
+
+    # Strip markdown fences if the model wrapped them anyway
+    fixed_code = re.sub(r"^```[\w]*\n", "", fixed_code)
+    fixed_code = re.sub(r"\n```$", "", fixed_code)
+
+    with open(target_file, "w") as f:
+        f.write(fixed_code + "\n")
+
+    print(f"✅ Fix written to {target_file}")
 
 def run_agent(title, body):
     # 1. Identify the file locally
     target_file = find_relevant_file(title)
+    if not target_file:
+        print("❌ No target file found. Aborting.")
+        return
     print(f"🔍 Scanner identified: {target_file}")
-    
+
     # 2. Create a new branch using GH CLI
     branch_name = f"fix-{target_file.split('.')[0]}"
-    os.system(f"git checkout -b {branch_name}")
-    
-    # 3. [HANDOFF TO CLAUDE] 
-    # At this point, you paste the file content into Claude Pro 
-    # and ask for the fix. Then save the fix to target_file.
-    
+    os.system(f"git checkout -b {shlex.quote(branch_name)}")
+
+    # 3. Generate the fix with Ollama
+    generate_fix(target_file, title, body)
+
     # 4. Push and Open PR via GH CLI
-    os.system(f"git add {target_file}")
-    os.system(f"git commit -m 'AI Refactor: {title}'")
-    os.system(f"git push origin {branch_name}")
-    
-    # Use the 'gh' command you just authorized!
-    os.system(f"gh pr create --title '{title}' --body '{body}'")
+    safe_title = shlex.quote(f"AI Refactor: {title}")
+    safe_body = shlex.quote(body or "")
+    os.system(f"git add {shlex.quote(target_file)}")
+    os.system(f"git commit -m {safe_title}")
+    os.system(f"git push origin {shlex.quote(branch_name)}")
+
+    os.system(f"gh pr create --title {shlex.quote(title)} --body {safe_body}")
     print(f"🚀 Pull Request Created for {target_file}!")
 
 if __name__ == "__main__":

--- a/listener.py
+++ b/listener.py
@@ -14,6 +14,10 @@ async def handle_github_issue(request: Request):
         print(f"🛠️ New Task: {issue_title}")
         
         # TRIGGER: Call the agent script with the issue details
-        subprocess.Popen(["python", "agent.py", issue_title, issue_body])
+        subprocess.Popen(["python", "agent.py", issue_title, issue_body or ""])
         
     return {"status": "accepted"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/scanner.py
+++ b/scanner.py
@@ -9,4 +9,12 @@ def find_relevant_file(issue_description):
     prompt = f"Given these files: {files}, which one relates to: '{issue_description}'? Output ONLY the filename."
     response = ollama.chat(model='llama3.1:8b-instruct-q8_0', messages=[{'role': 'user', 'content': prompt}])
     
-    return response['message']['content'].strip()
+    filename = response['message']['content'].strip()
+    
+    if os.path.exists(filename):
+        return filename
+    else:
+        if files:
+            return files[0]
+        else:
+            return None


### PR DESCRIPTION
The find_relevant_file function should handle the case where ollama returns a filename that does not exist. Add a fallback that returns the first file in the list if the LLM response is not a valid filename.